### PR TITLE
Add testing infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+*.egg-info
+.tox
+.stestr

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=${TESTS_DIR:-./httpmi/tests/}
+top_dir=./

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install: pip install tox-travis
+script: tox

--- a/httpmi/exception.py
+++ b/httpmi/exception.py
@@ -2,6 +2,7 @@
 # Licensed under the terms of the Apache 2.0 license. See LICENSE file in
 # https://github.com/yahoo/httpmi
 
+
 class BaseException(Exception):
     _msg_fmt = 'An unknown error occurred.'
 

--- a/httpmi/ipmi.py
+++ b/httpmi/ipmi.py
@@ -24,7 +24,7 @@ def get_power(credentials):
 def set_power(credentials, state):
     if state not in VALID_POWER_STATES:
         raise exception.InvalidPowerState(state=state)
-    connection = _connect(credentials).set_power(state)['powerstate']
+    res = _connect(credentials).set_power(state)['powerstate']
     if 'powerstate' in res:
         # already in the desired state, return immediately
         return res['powerstate']
@@ -47,6 +47,6 @@ def set_boot_device(credentials, device, persist=False, uefiboot=False):
                                              uefiboot=uefiboot)['bootdev']
 
 
-# TODO ironic also supports:
+# TODO(jroll) ironic also supports:
 # get sensors data
 # inject nmi

--- a/httpmi/tests/base.py
+++ b/httpmi/tests/base.py
@@ -1,0 +1,9 @@
+# Copyright 2018, Oath Inc
+# Licensed under the terms of the Apache 2.0 license. See LICENSE file in
+# https://github.com/yahoo/httpmi
+
+from oslotest import base
+
+
+class TestCase(base.BaseTestCase):
+    """Test case base class for all unit tests."""

--- a/httpmi/tests/test_api.py
+++ b/httpmi/tests/test_api.py
@@ -1,0 +1,10 @@
+# Copyright 2018, Oath Inc
+# Licensed under the terms of the Apache 2.0 license. See LICENSE file in
+# https://github.com/yahoo/httpmi
+
+from httpmi.tests import base
+
+
+class PowerTestCase(base.TestCase):
+    def test_foo(self):
+        pass

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+hacking
+stestr
+oslotest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,34 @@
+[tox]
+minversion = 1.8
+skipsdist = True
+envlist = py36,py27,pep8
+
+[testenv]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+setenv = VIRTUAL_ENV={envdir}
+         LANGUAGE=en_US
+         LC_ALL=en_US.UTF-8
+         TESTS_DIR=./httpmi/tests/
+deps =
+  -r{toxinidir}/requirements.txt
+  -r{toxinidir}/test-requirements.txt
+commands =
+    stestr run {posargs}
+
+[testenv:pep8]
+basepython = python3
+whitelist_externals = bash
+commands =
+    flake8
+
+[flake8]
+# H102 -> we use Oath's license header
+ignore = H102
+filename = *.py
+exclude =  .venv,.git,.tox,dist,doc,*lib/python*,*egg,build
+
+[travis]
+python =
+  2.7: py27
+  3.6: py36, pep8


### PR DESCRIPTION
Sets up tox for pep8 and unit tests. Adds a travis-ci config file. Also
fixes a few pep8 failures (which were real bugs!).