### PR TITLE
Add port parameter, fix a bug, add some examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,38 @@ API call must pass the BMC IP address and credentials in the keys
 
   Response value may be "on" or "off".
 
+Some examples in curl::
+
+    $ curl -X POST \
+           --form user=admin --form password=password \
+           --form bmc=10.88.209.247 --form port=6230
+           --form state=off \
+           http://localhost:5000/power
+
+    {"state":"off"}
+
+    $ curl -X GET \
+           --form user=admin --form password=password \
+           --form bmc=10.88.209.247 --form port=6230 \
+           http://localhost:5000/power
+
+    {"state":"off"}
+
+    $ curl -X POST \
+           --form user=admin --form password=password \
+           --form bmc=10.88.209.247 --form port=6230 \
+           --form device=hd \
+           http://localhost:5000/boot-device
+
+    {"device":"hd"}
+
+    $ curl -X GET \
+           --form user=admin --form password=password \
+           --form bmc=10.88.209.247 --form port=6230 \
+           http://localhost:5000/boot-device
+
+    {"device":"hd"}
+
 ## Contribute
 
 Please refer to [the contributing.md file](Contributing.md) for information

--- a/httpmi/api.py
+++ b/httpmi/api.py
@@ -11,11 +11,17 @@ from httpmi import ipmi
 
 app = Flask(__name__)
 
-CREDS_KEYS = ['bmc', 'user', 'password']
+CREDS_KEYS = ('bmc', 'user', 'password')
+CREDS_OPTIONAL_KEYS = ('port',)
 
 
 def _get_bmc_credentials():
-    return {k: request.form[k] for k in CREDS_KEYS}
+    creds = {k: request.form[k] for k in CREDS_KEYS}
+    for key in CREDS_OPTIONAL_KEYS:
+        val = request.form.get(key)
+        if val:
+            creds[key] = val
+    return creds
 
 
 @app.route('/power', methods=['GET', 'POST'])

--- a/httpmi/ipmi.py
+++ b/httpmi/ipmi.py
@@ -25,7 +25,7 @@ def get_power(credentials):
 def set_power(credentials, state):
     if state not in VALID_POWER_STATES:
         raise exception.InvalidPowerState(state=state)
-    res = _connect(credentials).set_power(state)['powerstate']
+    res = _connect(credentials).set_power(state)
     if 'powerstate' in res:
         # already in the desired state, return immediately
         return res['powerstate']

--- a/httpmi/ipmi.py
+++ b/httpmi/ipmi.py
@@ -13,6 +13,7 @@ VALID_BOOT_DEVICES = ('network', 'hd')
 
 def _connect(credentials):
     return command.Command(bmc=credentials['bmc'],
+                           port=int(credentials.get('port', 623)),
                            userid=credentials['user'],
                            password=credentials['password'])
 


### PR DESCRIPTION
This is a few commits:

* Add an optional port parameter, defaulting to 623 (the standard for IPMI). At a minimum, this is needed to test with devstack.

* Fix a silly coding error when setting power state.

* Add some usage examples with curl (since I even forget how to use it all the time).